### PR TITLE
Add higher-order component option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "react"
   ],
   "rules": {
-    "indent": [2, 2],
+    "indent": [2, 2, { "SwitchCase": 1 }],
     "no-underscore-dangle": 0,
     "semi": [2, "always"],
     "quotes": [2, "single", "avoid-escape"],

--- a/demo/ButtonWithDecorator.js
+++ b/demo/ButtonWithDecorator.js
@@ -15,25 +15,23 @@ class Button extends Component {
   };
 
   render() {
+    const { children, disabled, kind, onClick, size } = this.props;
+
     const buttonProps = {
       className: this.getClassName({
-        modifiers: classNames(this.props.kind, this.props.size),
-        states: classNames({
-          disabled: this.props.disabled
-        })
+        modifiers: classNames(kind, size),
+        states: classNames({ disabled })
       }),
-      onClick: this.props.onClick && this.props.onClick()
+      onClick: onClick && onClick()
     };
 
     const textProps = {
-      className: this.getClassName({
-        descendantName: 'text'
-      })
+      className: this.getClassName({ descendantName: 'text' })
     };
 
     return (
       <button { ...buttonProps }>
-        <span { ...textProps }>{ this.props.children }</span>
+        <span { ...textProps }>{ children }</span>
       </button>
     );
   }

--- a/demo/ButtonWithHigherOrder.js
+++ b/demo/ButtonWithHigherOrder.js
@@ -1,25 +1,24 @@
 'use strict';
 
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import SuitCssify from '../index';
 import classNames from 'classnames';
 
-let Button = React.createClass({
-  mixins: [SuitCssify.mixin],
-
-  propTypes: {
+class Button extends Component {
+  static propTypes = {
     children: PropTypes.node,
     disabled: PropTypes.bool,
+    getClassName: PropTypes.func.isRequired,
     kind: PropTypes.oneOf(['primary', 'secondary']),
     onClick: PropTypes.func,
     size: PropTypes.oneOf(['small', 'medium', 'large'])
-  },
+  };
 
   render() {
-    const { children, disabled, kind, onClick, size } = this.props;
+    const { children, disabled, getClassName, kind, onClick, size } = this.props;
 
     const buttonProps = {
-      className: this.getClassName({
+      className: getClassName({
         modifiers: classNames(kind, size),
         states: classNames({ disabled })
       }),
@@ -27,7 +26,7 @@ let Button = React.createClass({
     };
 
     const textProps = {
-      className: this.getClassName({ descendantName: 'text' })
+      className: getClassName({ descendantName: 'text' })
     };
 
     return (
@@ -36,6 +35,6 @@ let Button = React.createClass({
       </button>
     );
   }
-});
+}
 
-export default Button;
+export default SuitCssify.higherOrder()(Button);

--- a/demo/ButtonWithUtility.js
+++ b/demo/ButtonWithUtility.js
@@ -18,17 +18,17 @@ const Button = React.createClass({
   },
 
   render() {
+    const { children, className, disabled, kind, onClick, size, utilities } = this.props;
+
     const buttonProps = {
       className: getClassName({
-        className: this.props.className,
+        className,
         componentName: this.constructor.displayName,
-        modifiers: classNames(this.props.kind, this.props.size),
-        states: classNames({
-          disabled: this.props.disabled
-        }),
-        utilities: this.props.utilities
+        modifiers: classNames(kind, size),
+        states: classNames({ disabled }),
+        utilities
       }),
-      onClick: this.props.onClick && this.props.onClick()
+      onClick: onClick && onClick()
     };
 
     const textProps = {
@@ -40,7 +40,7 @@ const Button = React.createClass({
 
     return (
       <button { ...buttonProps }>
-        <span { ...textProps }>{ this.props.children }</span>
+        <span { ...textProps }>{ children }</span>
       </button>
     );
   }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { default as ButtonWithDecorator } from './ButtonWithDecorator';
+import { default as ButtonWithHigherOrder } from './ButtonWithHigherOrder';
 import { default as ButtonWithMixin } from './ButtonWithMixin';
 import { default as ButtonWithUtility } from './ButtonWithUtility';
 
@@ -23,6 +24,24 @@ ReactDOM.render(
         <ButtonWithDecorator kind="secondary" size="large" disabled>Hello</ButtonWithDecorator>
         <ButtonWithDecorator kind="secondary" size="large" utilities="pullRight">Hello</ButtonWithDecorator>
         <ButtonWithDecorator kind="secondary" size="large" utilities="pullRight" className="someOtherClass">Hello</ButtonWithDecorator>
+      </div>
+    </div>
+    <hr />
+    <div>
+      <h2>Higher-order component examples</h2>
+      <div className="group">
+        <ButtonWithHigherOrder kind="primary" size="small">Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="primary" size="medium">Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="primary" size="large" disabled>Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="primary" size="large" utilities="pullRight">Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="primary" size="large" utilities="pullRight" className="someOtherClass">Hello</ButtonWithHigherOrder>
+      </div>
+      <div className="group">
+        <ButtonWithHigherOrder kind="secondary" size="small">Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="secondary" size="medium">Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="secondary" size="large" disabled>Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="secondary" size="large" utilities="pullRight">Hello</ButtonWithHigherOrder>
+        <ButtonWithHigherOrder kind="secondary" size="large" utilities="pullRight" className="someOtherClass">Hello</ButtonWithHigherOrder>
       </div>
     </div>
     <hr />

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict';
 
 import decorator from './lib/decorator';
+import higherOrder from './lib/higher-order';
 import mixin from './lib/mixin';
 import utility from './lib/utility';
 
 const SuitCssify = {
   decorator,
+  higherOrder,
   mixin,
   utility
 };

--- a/lib/higher-order.js
+++ b/lib/higher-order.js
@@ -1,0 +1,34 @@
+'use strict';
+
+import React from 'react';
+import utility from './utility';
+
+export default function(namespace) {
+  return function(Component) {
+    const componentName = Component.displayName || Component.name;
+    const getClassName = (options) => utility({ namespace, componentName, ...options });
+
+    return class SuitCssifyHigherOrder extends React.Component {
+      static propTypes = {
+        className: React.PropTypes.string,
+        utilities: React.PropTypes.string
+      };
+
+      render() {
+        let finalGetClassName = getClassName;
+        const { className, utilities } = this.props;
+        if (className || utilities) {
+          const propsOptions = {};
+          if (className) {
+            propsOptions.className = className;
+          }
+          if (utilities) {
+            propsOptions.utilities = utilities;
+          }
+          finalGetClassName = (options) => getClassName({ ...options, ...propsOptions });
+        }
+        return <Component { ...this.props } getClassName={ finalGetClassName } />;
+      }
+    };
+  };
+}

--- a/lib/higher-order.js
+++ b/lib/higher-order.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React from 'react';
+import React, { PropTypes } from 'react';
 import utility from './utility';
 
 export default function(namespace) {
@@ -10,8 +10,8 @@ export default function(namespace) {
 
     return class SuitCssifyHigherOrder extends React.Component {
       static propTypes = {
-        className: React.PropTypes.string,
-        utilities: React.PropTypes.string
+        className: PropTypes.string,
+        utilities: PropTypes.string
       };
 
       render() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-suitcssify",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "A React component utility to generate CSS class names that conform to SUIT CSS naming conventions.",
   "main": "./dist/index.js",
   "scripts": {
@@ -8,6 +8,7 @@
     "build": "npm run clean && $(npm bin)/babel ./index.js --source-maps --out-dir ./dist && $(npm bin)/babel ./lib --source-maps --out-dir ./dist/lib",
     "demo": "$(npm bin)/browserify ./demo/demo.js -t babelify -o ./dist/demo.js && open ./demo/index.html",
     "lint": "$(npm bin)/eslint .",
+    "pack-ls": "npm pack && tar -tzvf react-suitcssify*.tgz && rm react-suitcssify*.tgz",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -20,7 +21,8 @@
     "react-component",
     "suitcss",
     "suit",
-    "css"
+    "css",
+    "BEM"
   ],
   "author": "Brent Ertz <brent.ertz@gmail.com>",
   "license": "MIT",
@@ -38,9 +40,12 @@
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.5.1",
     "jest-cli": "^0.5.10",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.1.0",
+    "react-addons-test-utils": "^15.1.0",
+    "react-dom": "^15.1.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0-0"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 
 A React component utility to generate CSS class names that conform to [SUIT CSS naming conventions](https://github.com/suitcss/suit/blob/master/doc/naming-conventions.md).
 
-__This utility can be used as a decorator, mixin, or utility function__.
-This means that you can use it with React components defined as ES6 classes.
+__This utility can be used as a higher-order component, decorator, mixin, or utility function__.
+This means that you can use it with React components defined as ES2015 classes.
 
 Provides a general purpose `getClassName(options)` method that accepts a variety of options for generating SUIT CSS conformant class names.
 
@@ -19,18 +19,18 @@ getClassName({
 })
 ```
 
-When using the decorator or mixin approach, the following sensible defaults are provided.
+When using the decorator or mixin approach, the following defaults are provided.
 
 * __className__  - `Component.props.className`  _Note that `Component.propTypes.className` is also added for convenience._
-* __componentName__ - `Component.constructor.displayName || Component.constructor.name`
+* __componentName__ - `Component.displayName || Component.name`
 * __namespace__ - `Component.namespace`
 * __utilities__ - `Component.props.utilities`  _Note that `Component.propTypes.utilities` is also added for convenience._
 
 When using the higher-order approach, the following defaults are provided.
 
-* __className__  - `props.className`
+* __className__  - `Component.props.className`
 * __componentName__ - `Component.displayName || Component.name`
-* __utilities__ - `props.utilities`
+* __utilities__ - `Component.props.utilities`
 
 ## Installation
 
@@ -40,10 +40,11 @@ npm install react-suitcssify
 
 ## Usage
 
-#### ES6 class with a decorator
+#### ES2015 class with a decorator
 
 ```JavaScript
 import React from 'react';
+import ReactDOM from 'react-dom';
 import SuitCssify from 'react-suitcssify';
 
 @SuitCssify.decorator
@@ -53,9 +54,9 @@ class MyComponent extends React.Component {
   }
 }
 
-React.render(<MyComponent/>, document.body);
+ReactDOM.render(<MyComponent/>, document.body);
 ```
-* _NOTE: Your codebase must support ES7 decorators to use this synax.  Alternatively, simply use the decorator as a wrapper function to achieve the same effect._
+* _NOTE: Your codebase must support ES7 decorators to use this syntax.  Alternatively, simply use the decorator as a wrapper function to achieve the same effect._
 
 #### As a higher-order component
 
@@ -63,24 +64,26 @@ This approach is necessary when working with [stateless functional React compone
 
 ```JavaScript
 import React from 'react';
+import ReactDOM from 'react-dom';
 import SuitCssify from 'react-suitcssify';
 
 const MyComponent = ({ getClassName }) => <div className={ getClassName() }></div>;
 
-const WrappedComponent = SuitCssify.higherOrder("optional_namespace")(MyComponent);
+const WrappedComponent = SuitCssify.higherOrder('optional_namespace')(MyComponent);
 
-React.render(<WrappedComponent/>, document.body);
+ReactDOM.render(<WrappedComponent/>, document.body);
 ```
 
-Here's an example with an ES6 class React component.
+Here's an example with an ES2015 class React component.
 
 ```JavaScript
 import React from 'react';
+import ReactDOM from 'react-dom';
 import SuitCssify from 'react-suitcssify';
 
 class MyComponent extends React.Component {
   static propTypes = {
-    React.PropTypes.func.isRequired
+    getClassName: React.PropTypes.func.isRequired
   };
 
   render() {
@@ -88,15 +91,16 @@ class MyComponent extends React.Component {
   }
 }
 
-const WrappedComponent = SuitCssify.higherOrder("optional_namespace")(MyComponent);
+const WrappedComponent = SuitCssify.higherOrder('optional_namespace')(MyComponent);
 
-React.render(<WrappedComponent/>, document.body);
+ReactDOM.render(<WrappedComponent/>, document.body);
 ```
 
 #### As a mixin
 
 ```JavaScript
 import React from 'react';
+import ReactDOM from 'react-dom';
 import SuitCssify from 'react-suitcssify';
 
 const MyComponent = React.createClass({
@@ -107,13 +111,14 @@ const MyComponent = React.createClass({
   }
 });
 
-React.render(<MyComponent/>, document.body);
+ReactDOM.render(<MyComponent/>, document.body);
 ```
 
 #### As a utility method
 
 ```JavaScript
 import React from 'react';
+import ReactDOM from 'react-dom';
 import SuitCssify from 'react-suitcssify';
 
 const getClassName = SuitCssify.utility;
@@ -124,7 +129,7 @@ const MyComponent = React.createClass({
   }
 });
 
-React.render(<MyComponent/>, document.body);
+ReactDOM.render(<MyComponent/>, document.body);
 ```
 
 
@@ -208,6 +213,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+* 3.1.0 - Add higher-order component option. Update React version and add to peerDependencies.  Other minor tweaks.
 * 3.0.2 - Update decorator to not use inheritance.  Update dev dependencies, including react 0.14.
 * 3.0.1 - Use destructuring assignment instead of Object.assign.  Utilize internal format method to de-dupe similar code.  Adjust imports.
 * 3.0.0 - Descendant elements no longer automatically inherit parent className.

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,11 @@ When using the decorator or mixin approach, the following sensible defaults are 
 * __namespace__ - `Component.namespace`
 * __utilities__ - `Component.props.utilities`  _Note that `Component.propTypes.utilities` is also added for convenience._
 
+When using the higher-order approach, the following defaults are provided.
+
+* __className__  - `props.className`
+* __componentName__ - `Component.displayName || Component.name`
+* __utilities__ - `props.utilities`
 
 ## Installation
 
@@ -42,8 +47,8 @@ import React from 'react';
 import SuitCssify from 'react-suitcssify';
 
 @SuitCssify.decorator
-MyComponent extends React.Component{
-  render: function() {
+class MyComponent extends React.Component {
+  render() {
     return <div className={ this.getClassName() }></div>
   }
 }
@@ -51,6 +56,42 @@ MyComponent extends React.Component{
 React.render(<MyComponent/>, document.body);
 ```
 * _NOTE: Your codebase must support ES7 decorators to use this synax.  Alternatively, simply use the decorator as a wrapper function to achieve the same effect._
+
+#### As a higher-order component
+
+This approach is necessary when working with [stateless functional React components](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#stateless-functional-components).
+
+```JavaScript
+import React from 'react';
+import SuitCssify from 'react-suitcssify';
+
+const MyComponent = ({ getClassName }) => <div className={ getClassName() }></div>;
+
+const WrappedComponent = SuitCssify.higherOrder("optional_namespace")(MyComponent);
+
+React.render(<WrappedComponent/>, document.body);
+```
+
+Here's an example with an ES6 class React component.
+
+```JavaScript
+import React from 'react';
+import SuitCssify from 'react-suitcssify';
+
+class MyComponent extends React.Component {
+  static propTypes = {
+    React.PropTypes.func.isRequired
+  };
+
+  render() {
+    return <div className={ this.props.getClassName() }></div>
+  }
+}
+
+const WrappedComponent = SuitCssify.higherOrder("optional_namespace")(MyComponent);
+
+React.render(<WrappedComponent/>, document.body);
+```
 
 #### As a mixin
 


### PR DESCRIPTION
Enable use of `react-suitcssify` with pure functional components

* Add higher-order component option (thanks @pbomb)
* Update demo and documentation
* Update React version and add to peerDependencies
* Other minor tweaks


