### PR TITLE
Upgrade babel / jest and improve performance of library

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,10 @@
 {
-  "stage": 0
+  "plugins": [
+    "transform-decorators-legacy"
+  ],
+  "presets" : [
+    "es2015",
+    "react",
+    "stage-1"
+  ]
 }

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1,40 +1,39 @@
 'use strict';
 
-jest.autoMockOff();
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactDOMServer from 'react-dom/server';
+import ReactTestUtils from 'react-addons-test-utils';
+import SuitCssify from '../index';
 
-const React = require('react');
-const ReactDOM = require('react-dom');
-const ReactDOMServer = require('react-dom/server');
-const ReactTestUtils = require('react-addons-test-utils');
-const SuitCssify = require('../index');
+const DECORATOR = 'decorator';
+const HIGHER_ORDER = 'higher order';
+const HIGHER_ORDER_STATELESS = 'higher order stateless';
+const MIXIN = 'mixin';
+const UTILITY = 'utility';
 
-const DECORATOR = 0;
-const HIGHER_ORDER = 1;
-const HIGHER_ORDER_STATELESS = 2;
-const MIXIN = 3;
-const UTILITY = 4;
-
-/* eslint-disable react/no-multi-comp, no-shadow, no-unused-vars */
+/* eslint-disable react/no-multi-comp */
 const ComponentFactory = {
-  build(kind, options={}, descendantOptions) {
+  build(kind, options={}, descendantOptions = null, useNewer = false) {
     let Component;
 
     switch(kind) {
       case DECORATOR:
         @SuitCssify.decorator
-        class Component extends React.Component{
+        class Component extends React.Component {
           render() {
-            return (
+            const ret = (
               <div className={ this.getClassName(options) }>
                 { descendantOptions && <span ref="descendant" className={ this.getClassName(descendantOptions) }></span> }
               </div>
             );
+            return ret;
           }
         }
         break;
 
       case HIGHER_ORDER:
-        class InnerCmp extends React.Component{
+        class InnerCmp extends React.Component {
           static propTypes = {
             getClassName: React.PropTypes.func.isRequired
           };
@@ -47,7 +46,7 @@ const ComponentFactory = {
             );
           }
         }
-        Component = SuitCssify.higherOrder('foo')(InnerCmp);
+        Component = SuitCssify.higherOrder('foo', useNewer)(InnerCmp);
         break;
 
       case HIGHER_ORDER_STATELESS:
@@ -57,7 +56,7 @@ const ComponentFactory = {
           </div>
         );
         InnerStateless.displayName = 'InnerStateless';
-        Component = SuitCssify.higherOrder('bar')(InnerStateless);
+        Component = SuitCssify.higherOrder('bar', useNewer)(InnerStateless);
         break;
 
       case MIXIN:

--- a/demo/ButtonWithUtility.js
+++ b/demo/ButtonWithUtility.js
@@ -4,7 +4,7 @@ import React, { PropTypes } from 'react';
 import SuitCssify from '../index';
 import classNames from 'classnames';
 
-const getClassName = SuitCssify.utility;
+const getClassName = SuitCssify.getClassName;
 
 const Button = React.createClass({
   propTypes: {

--- a/index.js
+++ b/index.js
@@ -3,13 +3,15 @@
 import decorator from './lib/decorator';
 import higherOrder from './lib/higher-order';
 import mixin from './lib/mixin';
-import utility from './lib/utility';
+import { getBaseComponentName, getClassName } from './lib/utility';
 
 const SuitCssify = {
   decorator,
+  getBaseComponentName,
+  getClassName,
   higherOrder,
   mixin,
-  utility
+  utility: getClassName
 };
 
 export default SuitCssify;

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -2,7 +2,7 @@
 
 import mixin from './mixin';
 
-function decorate(Component) {
+export default function decorate(Component) {
   Component.displayName = Component.displayName || Component.name;
 
   Component.propTypes = {
@@ -14,5 +14,3 @@ function decorate(Component) {
 
   return Component;
 }
-
-export default decorate;

--- a/lib/higher-order.js
+++ b/lib/higher-order.js
@@ -1,21 +1,35 @@
 'use strict';
 
 import React, { PropTypes } from 'react';
-import utility from './utility';
+import { getClassName, getBaseComponentName } from './utility';
 
 export default function(namespace) {
   return function(Component) {
-    const componentName = Component.displayName || Component.name;
-    const getClassName = (options) => utility({ namespace, componentName, ...options });
+    const componentName = Component.displayName || Component.name || 'Component';
+    const baseComponentName = getBaseComponentName(componentName, namespace);
+    const higherOrderGetClassName = (options) => {
+      const finalOptions = { ...options };
+      const hasComponentNameProp = options.hasOwnProperty('componentName');
+      const hasNamespaceProp = options.hasOwnProperty('namespace');
+
+      if (hasNamespaceProp || hasComponentNameProp) {
+        finalOptions.componentName = hasComponentNameProp ? options.componentName : componentName;
+        finalOptions.namespace = hasNamespaceProp ? options.namespace : namespace;
+      } else {
+        finalOptions.baseComponentName = baseComponentName;
+      }
+      return getClassName(finalOptions);
+    };
 
     return class SuitCssifyHigherOrder extends React.Component {
+      static displayName = `SuitCssify(${componentName})`;
       static propTypes = {
         className: PropTypes.string,
         utilities: PropTypes.string
       };
 
       render() {
-        let finalGetClassName = getClassName;
+        let finalGetClassName = higherOrderGetClassName;
         const { className, utilities } = this.props;
         if (className || utilities) {
           const propsOptions = {};
@@ -25,7 +39,14 @@ export default function(namespace) {
           if (utilities) {
             propsOptions.utilities = utilities;
           }
-          finalGetClassName = (options) => getClassName({ ...options, ...propsOptions });
+          finalGetClassName = (options) => {
+            const finalOptions = { ...options };
+            // Use className & utilities on props unless descendantName is supplied
+            if (!options.hasOwnProperty('descendantName')) {
+              Object.assign(finalOptions, propsOptions);
+            }
+            return higherOrderGetClassName(finalOptions);
+          };
         }
         return <Component { ...this.props } getClassName={ finalGetClassName } />;
       }

--- a/lib/mixin.js
+++ b/lib/mixin.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { PropTypes } from 'react';
-import utility from './utility';
+import { getClassName } from './utility';
 
 const mixin = {
   propTypes: {
@@ -9,7 +9,22 @@ const mixin = {
     utilities: PropTypes.string
   },
 
-  getClassName: utility
+  getClassName: function(config = {}) {
+    const options = { ...config };
+    if (!options.hasOwnProperty('className')) {
+      options.className = this && (config.descendantName ? null : (this.props && this.props.hasOwnProperty('className') && this.props.className)) || null;
+    }
+    if (!(options.hasOwnProperty('baseComponentName') || options.hasOwnProperty('componentName'))) {
+      options.componentName = this && (this.constructor.displayName || this.constructor.name) || 'Undefined';
+    }
+    if (!options.hasOwnProperty('namespace')) {
+      options.namespace = this && this.namespace || null;
+    }
+    if (!options.hasOwnProperty('utilities')) {
+      options.utilities = this && (config.descendantName ? null : (this.props && this.props.hasOwnProperty('utilities') && this.props.utilities)) || null;
+    }
+    return getClassName(options);
+  }
 };
 
 export default mixin;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -1,22 +1,29 @@
 'use strict';
 
+const CAMELIZE_REGEX_UPPER_CASE = /[\-_/\.\s]+(.)?/g;
+const CAMELIZE_REGEX_LOWER_CASE = /^(.)/;
+
 function capitalize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 function camelize(string) {
   return string
-    .replace(/[\-_/\.\s]+(.)?/g, (match, chr) => chr.toUpperCase())
-    .replace(/^(.)/, (match, chr) => chr.toLowerCase());
+    .replace(CAMELIZE_REGEX_UPPER_CASE, (match, chr) => chr.toUpperCase())
+    .replace(CAMELIZE_REGEX_LOWER_CASE, (match, chr) => chr.toLowerCase());
 }
 
-function getBaseClassName({ namespace, componentName, descendantName }) {
-  componentName = capitalize(camelize(componentName));
+export function getBaseComponentName(componentName, namespace) {
+  const sanitizedComponentName = capitalize(camelize(componentName));
+  return namespace ? `${namespace}-${sanitizedComponentName}` : sanitizedComponentName;
+};
 
-  let baseClassName = namespace ? `${namespace}-${componentName}` : componentName;
-  baseClassName = descendantName ? `${baseClassName}-${camelize(descendantName)}` : baseClassName;
-
-  return baseClassName;
+function getConfiguredClassName({ namespace, componentName, descendantName, baseComponentName }) {
+  let baseClassName = baseComponentName;
+  if (componentName || namespace) {
+    baseClassName = getBaseComponentName(componentName, namespace);
+  }
+  return descendantName ? `${baseClassName}-${camelize(descendantName)}` : baseClassName;
 }
 
 function format(values, prefix) {
@@ -26,21 +33,11 @@ function format(values, prefix) {
     .join(' ');
 }
 
-function getClassName(config={}) {
+export function getClassName(options = {}) {
   // Allow utilities and className to be set on descendants when using utility function or passed in directly.
   // Do not automatically inherit utilities or className from top level component onto descendants when using mixin or decorator.
-  const defaults = {
-    className: this && (config.descendantName ? null : (this.props && this.props.hasOwnProperty('className') && this.props.className)) || null,
-    componentName: this && (this.constructor.displayName || this.constructor.name) || 'Undefined',
-    descendantName: null,
-    modifiers: null,
-    namespace: this && this.namespace || null,
-    states: null,
-    utilities: this && (config.descendantName ? null : (this.props && this.props.hasOwnProperty('utilities') && this.props.utilities)) || null
-  };
 
-  const options = { ...defaults, ...config };
-  const baseClassName = getBaseClassName(options);
+  const baseClassName = getConfiguredClassName(options);
 
   const classNames = [
     baseClassName
@@ -55,5 +52,3 @@ function getClassName(config={}) {
 
   return classNames;
 }
-
-export default getClassName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-suitcssify",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A React component utility to generate CSS class names that conform to SUIT CSS naming conventions.",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "demo": "$(npm bin)/browserify ./demo/demo.js -t babelify -o ./dist/demo.js && open ./demo/index.html",
     "lint": "$(npm bin)/eslint .",
     "pack-ls": "npm pack && tar -tzvf react-suitcssify*.tgz && rm react-suitcssify*.tgz",
-    "perf-test": "babel-node bin/perf-test.js",
     "prepublish": "npm run build",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "demo": "$(npm bin)/browserify ./demo/demo.js -t babelify -o ./dist/demo.js && open ./demo/index.html",
     "lint": "$(npm bin)/eslint .",
     "pack-ls": "npm pack && tar -tzvf react-suitcssify*.tgz && rm react-suitcssify*.tgz",
+    "perf-test": "babel-node bin/perf-test.js",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -31,15 +32,22 @@
   },
   "homepage": "https://github.com/brentertz/react-suitcssify",
   "devDependencies": {
-    "babel": "^5.4.7",
-    "babel-eslint": "^4.1.3",
-    "babel-jest": "^5.2.0",
-    "babelify": "^6.1.1",
-    "browserify": "^11.2.0",
+    "babel-cli": "6.9.0",
+    "babel-core": "6.9.1",
+    "babel-eslint": "6.0.4",
+    "babel-jest": "12.1.0",
+    "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-preset-es2015": "6.9.0",
+    "babel-preset-react": "6.5.0",
+    "babel-preset-stage-1": "6.5.0",
+    "babel-register": "6.9.0",
+    "babel-runtime": "6.9.2",
+    "babelify": "7.3.0",
+    "browserify": "13.0.1",
     "classnames": "^2.1.1",
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.5.1",
-    "jest-cli": "^0.5.10",
+    "jest": "12.1.1",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.1.0"
@@ -48,10 +56,7 @@
     "react": "^0.14.0 || ^15.0.0-0"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "testPathIgnorePatterns": [
-      "node_modules"
-    ],
+    "automock": false,
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react",
       "<rootDir>/node_modules/classnames"


### PR DESCRIPTION
This changeset does a couple of things to improve performance of the
library.

First, it doesn't calculate all the default options in the
utility getClassName function. Instead, it only calculates the ones
that weren't set in the call. And that logic was moved into the mixin
(which is also used by the decorator) so that direct calls to utility
or the HOC approach don't look for all those default on `this`.

Second, it configures the base component name for the HOC when the
HOC is defined instead of on each invocation.

I ran some minor performance benchmarks that indicated these changes help somewhat, although Jest v12 seems to get much slower after running tests for each type of usage in lib/, so I didn't include the performance test. All the tests still pass, so I feel good that I'm not changing any behaviors.