### PR TITLE
Null check on options in higher-order.js

### DIFF
--- a/lib/higher-order.js
+++ b/lib/higher-order.js
@@ -9,8 +9,8 @@ export default function(namespace) {
     const baseComponentName = getBaseComponentName(componentName, namespace);
     const higherOrderGetClassName = (options) => {
       const finalOptions = { ...options };
-      const hasComponentNameProp = options.hasOwnProperty('componentName');
-      const hasNamespaceProp = options.hasOwnProperty('namespace');
+      const hasComponentNameProp = options && options.hasOwnProperty('componentName');
+      const hasNamespaceProp = options && options.hasOwnProperty('namespace');
 
       if (hasNamespaceProp || hasComponentNameProp) {
         finalOptions.componentName = hasComponentNameProp ? options.componentName : componentName;


### PR DESCRIPTION
When I copy-pasted the example for the higher order component usage, I kept getting an error on the options.hasOwnProperty checks on lines 12 & 13. Adding a quick null check fixes the issue and everything works like I'd expect.